### PR TITLE
Don't break lines after numbers

### DIFF
--- a/xml/Parser.lua
+++ b/xml/Parser.lua
@@ -7,7 +7,7 @@
 
 --]]------------------------------------------------------
 local core = require 'xml.core'
-local lub  = require 'lub'
+local lub  = require 'xml.lubsubset'
 local lib  = core.Parser
 
 -- ## Parser types

--- a/xml/init.lua
+++ b/xml/init.lua
@@ -169,6 +169,7 @@ local function doDump(data, indent, output, last, depth, max_depth)
         last = 'n'
       elseif typ == 'number' then
         insert(output, tostring(child))
+        last = 's'
       else
         local s = escape(child)
         insert(output, s)

--- a/xml/init.lua
+++ b/xml/init.lua
@@ -1,35 +1,18 @@
 --[[------------------------------------------------------
-  # Very fast xml parser for Lua <a href="https://travis-ci.org/lubyk/xml"><img src="https://travis-ci.org/lubyk/xml.png" alt="Build Status"></a> 
 
-  This parser uses [RapidXML](http://rapidxml.sourceforge.net/) to parse XML
-  content.
-
-  <html><a href="https://github.com/lubyk/xml"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png" alt="Fork me on GitHub"></a></html>
-
-  *MIT license* &copy Marcin Kalicinski 2006, 2009, Gaspard Bucher 2014.
-
-  ## Installation
-  
-  With [luarocks](http://luarocks.org):
-
-    $ luarocks install xml
-  
-  ## Usage example
-
-    local data = xml.load(some_xml)
-
-    local xml_string = xml.dump(some_table)
+  This is a fork of the lubyk XML module. Since the module depends
+  only on a few functions of the lub module, these are imported here
+  to avoid installing more dependencies
 
 --]]-----------------------------------------------------
-local lub     = require 'lub'
-local lib     = lub.Autoload 'xml'
+local lub     = require 'xml.lubsubset'
+local lib     = {}
 local ipairs, pairs, insert, type,
       match, tostring =
       ipairs, pairs, table.insert, type,
       string.match, tostring
 
-local parser  = lib.Parser()
-
+local parser  = require 'xml.Parser'
 
 -- Current version respecting [semantic versioning](http://semver.org).
 lib.VERSION = '1.1.2'
@@ -37,8 +20,6 @@ lib.VERSION = '1.1.2'
 lib.DEPENDS = { -- doc
   -- Compatible with Lua 5.1 to 5.3 and LuaJIT
   'lua >= 5.1, < 5.4',
-  -- Uses [Lubyk base library](http://doc.lubyk.org/lub.html)
-  'lub >= 1.0.3, < 2',
 }
 
 -- nodoc
@@ -55,7 +36,7 @@ lib.DESCRIPTION = {
 
     Read the documentation at http://doc.lubyk.org/xml.html.
   ]],
-  homepage = "http://doc.lubyk.org/"..lib.type..".html",
+  homepage = "http://doc.lubyk.org/",
   author   = "Gaspard Bucher",
   license  = "MIT",
 }

--- a/xml/lubsubset.lua
+++ b/xml/lubsubset.lua
@@ -1,0 +1,85 @@
+--[[------------------------------------------------------
+
+  This is a fork of the lubyk XML module. Since the module depends
+  only on a few functions of the lub module, these are imported here
+  to avoid installing more dependencies
+
+--]]-----------------------------------------------------
+
+local lib     = {}
+local ipairs, pairs, insert, type,
+      match, tostring =
+      ipairs, pairs, table.ins
+      
+-- Join elements of a table @list@ with separator @sep@. Returns a string.
+--
+--   local x = lk.join({'foo', 'bar', 'baz'}, '.')
+--   --> 'foo.bar.baz'
+function lib.join(list, sep)
+  local res = nil
+  for _, part in ipairs(list) do
+    if not res then
+      res = part
+    else
+      res = res .. sep .. part
+    end
+  end
+  return res or ''
+end
+
+-- Return the content of a file as a lua string (not suitable for very long
+-- content where parsing the file chunks by chunks is better). The method
+-- accepts either a single @path@ argument or a @basepath@ and relative @path@.
+function lib.content(basepath, path)
+  if path then
+    path = string.format('%s/%s', basepath, path)
+  else
+    path = basepath
+  end
+  local f = assert(io.open(path, 'rb'))
+  local s = f:read('*all')
+  f:close()
+  return s
+end
+
+-- [Breath-first search](https://en.wikipedia.org/wiki/Breadth-first_search) with max depth testing. See #search for usage.
+function lib.search(data, func, max_depth)
+  local max_depth = max_depth or 3000
+  local queue = {}
+  local depth = {} -- depth queue
+  local head  = 1
+  local tail  = 1
+  local function push(e, d)
+    queue[tail] = e
+    depth[tail] = d
+    tail = tail + 1
+  end
+
+  local function pop()
+    if head == tail then return nil end
+    local e, d = queue[head], depth[head]
+    head = head + 1
+    return e, d
+  end
+
+  local elem = data
+  local d = 1
+  while elem and d <= max_depth do
+    local r = func(elem)
+    if r then return elem end
+    for _, child in ipairs(elem) do
+      if type(child) == 'table' then
+        push(child, d + 1)
+      end
+    end
+    elem, d = pop()
+  end
+
+  if d and d > max_depth then
+    error(format('Could not finish search: maximal depth of %i reached.', max_depth))
+  else
+    return nil
+  end
+end
+
+return lib


### PR DESCRIPTION
The lubyk xml library inserts newlines after numbers by default but not after strings. This makes the output larger than needed and can cause problems with intolerant third-party xml parsers.

I have to generate XML for a legacy parser that does not parse the numbers correctly of there is white space after the number.