### PR TITLE
Added support for FreeBSD to rockspec

### DIFF
--- a/xml-1.1.3-1.rockspec
+++ b/xml-1.1.3-1.rockspec
@@ -44,6 +44,15 @@ build = {
     },
   },
   platforms = {
+    freebsd = {
+      modules = {
+        ['xml.core'] = {
+          sources = {
+          },
+          libraries = {'c++'},
+        },
+      },
+    },
     linux = {
       modules = {
         ['xml.core'] = {


### PR DESCRIPTION
Note that FreeBSD 10 and forward use libc++ by default rather than libstdc++,
on i386, amd64, and arm.
