### PR TITLE
fix(dub): update dub to C++17 style exception notation

### DIFF
--- a/src/bind/dub/dub.cpp
+++ b/src/bind/dub/dub.cpp
@@ -413,7 +413,7 @@ void dub::pushudata(lua_State *L, const void *cptr, const char *tname, bool gc) 
 // These methods are slight adaptations from luaxlib.c
 // Copyright (C) 1994-2008 Lua.org, PUC-Rio.
 
-lua_Number dub::checknumber(lua_State *L, int narg) throw(TypeException) {
+lua_Number dub::checknumber(lua_State *L, int narg) noexcept(false) {
 #ifdef DUB_LUA_FIVE_ONE
   lua_Number d = lua_tonumber(L, narg);
   if (d == 0 && !lua_isnumber(L, narg))  /* avoid extra test when d is not 0 */
@@ -428,7 +428,7 @@ lua_Number dub::checknumber(lua_State *L, int narg) throw(TypeException) {
 #endif
 }
 
-lua_Integer dub::checkinteger(lua_State *L, int narg) throw(TypeException) {
+lua_Integer dub::checkinteger(lua_State *L, int narg) noexcept(false) {
 #ifdef DUB_LUA_FIVE_ONE
   lua_Integer d = lua_tointeger(L, narg);
   if (d == 0 && !lua_isnumber(L, narg))  /* avoid extra test when d is not 0 */
@@ -443,13 +443,13 @@ lua_Integer dub::checkinteger(lua_State *L, int narg) throw(TypeException) {
 #endif
 }
 
-const char *dub::checklstring(lua_State *L, int narg, size_t *len) throw(TypeException) {
+const char *dub::checklstring(lua_State *L, int narg, size_t *len) noexcept(false) {
   const char *s = lua_tolstring(L, narg, len);
   if (!s) throw TypeException(L, narg, lua_typename(L, LUA_TSTRING));
   return s;
 }
 
-void **dub::checkudata(lua_State *L, int ud, const char *tname, bool keep_mt) throw(dub::Exception) {
+void **dub::checkudata(lua_State *L, int ud, const char *tname, bool keep_mt) noexcept(false) {
   void **p = (void**)lua_touserdata(L, ud);
   if (p != NULL) {  /* value is a userdata? */
     if (lua_getmetatable(L, ud)) {  /* does it have a metatable? */
@@ -500,7 +500,7 @@ static inline void **dub_cast_ud(lua_State *L, int ud, const char *tname) {
   return NULL;
 }
 
-static inline void **getsdata(lua_State *L, int ud, const char *tname, bool keep_mt) throw() {
+static inline void **getsdata(lua_State *L, int ud, const char *tname, bool keep_mt) noexcept(false) {
   void **p = (void**)lua_touserdata(L, ud);
   if (p != NULL) {  /* value is a userdata? */
     if (lua_getmetatable(L, ud)) {  /* does it have a metatable? */
@@ -593,7 +593,7 @@ void **dub::issdata(lua_State *L, int ud, const char *tname, int type) {
   }
 }
 
-void **dub::checksdata(lua_State *L, int ud, const char *tname, bool keep_mt) throw(dub::Exception) {
+void **dub::checksdata(lua_State *L, int ud, const char *tname, bool keep_mt) noexcept(false) {
   void **p = getsdata(L, ud, tname, keep_mt);
   if (!p) {
     throw dub::TypeException(L, ud, tname);
@@ -604,7 +604,7 @@ void **dub::checksdata(lua_State *L, int ud, const char *tname, bool keep_mt) th
   return p;
 }
 
-void **dub::checksdata_d(lua_State *L, int ud, const char *tname) throw(dub::Exception) {
+void **dub::checksdata_d(lua_State *L, int ud, const char *tname) noexcept(false) {
   void **p = getsdata(L, ud, tname, false);
   if (!p) {
     throw dub::TypeException(L, ud, tname);

--- a/src/bind/dub/dub.h
+++ b/src/bind/dub/dub.h
@@ -295,16 +295,16 @@ void register_const(lua_State *L, const const_Reg *l);
 
 // These provide the same funcionality as their equivalent luaL_check... but they
 // throw std::exception which can be caught (eventually to call lua_error).
-lua_Number checknumber(lua_State *L, int narg) throw(dub::TypeException);
-lua_Integer checkinteger(lua_State *L, int narg) throw(dub::TypeException);
-const char *checklstring(lua_State *L, int narg, size_t *len) throw(dub::TypeException);
-void **checkudata(lua_State *L, int ud, const char *tname, bool keep_mt = false) throw(dub::Exception);
+lua_Number checknumber(lua_State *L, int narg) noexcept(false);
+lua_Integer checkinteger(lua_State *L, int narg) noexcept(false);
+const char *checklstring(lua_State *L, int narg, size_t *len) noexcept(false);
+void **checkudata(lua_State *L, int ud, const char *tname, bool keep_mt = false) noexcept(false);
 
 // Super aware userdata calls (finds userdata inside provided table with table.super).
-void **checksdata(lua_State *L, int ud, const char *tname, bool keep_mt = false) throw(dub::Exception);
+void **checksdata(lua_State *L, int ud, const char *tname, bool keep_mt = false) noexcept(false);
 // Super aware userdata calls that DOES NOT check for dangling pointers (used in 
 // __gc binding).
-void **checksdata_d(lua_State *L, int ud, const char *tname) throw(dub::Exception);
+void **checksdata_d(lua_State *L, int ud, const char *tname) noexcept(false);
 // Return pointer if the type is correct. Used to resolve overloaded functions when there
 // is no other alternative (arg count, native types). We return the pointer so that we can
 // optimize away the corresponding 'dub_checksdata'.
@@ -314,11 +314,11 @@ void **issdata(lua_State *L, int ud, const char *tname, int type);
 // implementations for luaL_error (luajit throws an exception on luaL_error).
 void **checksdata_n(lua_State *L, int ud, const char *tname, bool keep_mt = false);
 
-inline const char *checkstring(lua_State *L, int narg) throw(dub::TypeException) {
+inline const char *checkstring(lua_State *L, int narg) noexcept(false) {
   return checklstring(L, narg, NULL);
 }
 
-inline int checkboolean(lua_State *L, int narg) throw() {
+inline int checkboolean(lua_State *L, int narg) noexcept {
   return lua_toboolean(L, narg);
 }
 


### PR DESCRIPTION
Fixes https://github.com/lubyk/xml/issues/19 by using more general `noexcept(false)` instead of pre-C++17 `throw(<exception>)` style